### PR TITLE
ci: remove custom release body generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,22 +351,6 @@ jobs:
           Write-Host "  • $($_.Name) ($([math]::Round($_.Length / 1MB, 2)) MB)"
         }
     
-    - name: 📝 Generate release body
-      shell: bash
-      env:
-        VERSION: ${{ needs.prepare-release.outputs.version }}
-      run: |
-        set -euo pipefail
-        TAG="$VERSION"
-        
-        # Create release body with package info (GitHub will auto-generate changelog)
-        {
-          printf '%s\n' "## 🎉 AGI.Kapster $TAG" "" "### 📦 Installer Packages" "" "**Windows:**" "- AGI.Kapster-*-win-x64.msi (MSI, x64)" "- AGI.Kapster-*-win-arm64.msi (MSI, arm64)" "" "**macOS:**" "- AGI.Kapster-*-osx-x64.pkg (Intel Mac)" "- AGI.Kapster-*-osx-arm64.pkg (Apple Silicon)" "" "**Linux:**" "- AGI.Kapster-*-linux-x64-portable.zip (Portable)" "" "### 📋 Additional Linux Packages" "- agi-kapster_*_amd64.deb (Debian/Ubuntu)" "- agi-kapster-*-1.x86_64.rpm (Red Hat/CentOS/Fedora)" "" "### 🔄 Auto-Update" "This release includes automatic update functionality. The application will:" "- Check for updates in the background (every 24 hours by default)" "- Download and install updates automatically (configurable)" "- Support cross-platform update distribution" "" "### 🔐 Integrity & Verification" "SHA-256 manifest: SHASUMS-$TAG.txt" "" "Linux/macOS verify all:" '```bash' "shasum -a 256 -c SHASUMS-$TAG.txt" '```' "" "PowerShell sample for verifying MSI (Windows):" '```powershell' "\$f = Get-Item .\\AGI.Kapster-*win-x64.msi" "\$expected = (Select-String -Path .\\SHASUMS-$TAG.txt -Pattern \$f.Name).Line.Split(' ',[System.StringSplitOptions]::RemoveEmptyEntries)[0]" "\$actual = (Get-FileHash \$f.FullName -Algorithm SHA256).Hash" "if (\$expected -ieq \$actual) { Write-Host 'Hash OK' } else { Write-Host 'Mismatch!' ; exit 1 }" '```' "";
-        } > custom-release-body.md
-        
-        echo "📋 Generated release body:"
-        head -n 20 custom-release-body.md
-    
     - name: 🚀 Update GitHub Release
       uses: softprops/action-gh-release@v2
       with:


### PR DESCRIPTION
- Remove the 'Generate release body' step that was causing workflow failures
- The workflow already uses 'generate_release_notes: true' in the GitHub Release action
- This eliminates the bash quoting issues in the printf command
- Simplifies the release workflow by relying on GitHub's automatic changelog generation

Fixes the release workflow exit code 1 error.