### PR TITLE
Fix hotkey startup readiness and Windows hotkey matching

### DIFF
--- a/.github/workflows/_reusable-multiplatform.yml
+++ b/.github/workflows/_reusable-multiplatform.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build-matrix:
-    name: 🚀 Build ${{ matrix.platform }}
+    name: ðŸš€ Build ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -39,27 +39,27 @@ jobs:
           - platform: linux-x64
             os: ubuntu-latest
           - platform: osx-x64
-            os: macos-13
+            os: macos-latest
           - platform: osx-arm64
             os: macos-latest
     
     steps:
-    - name: 📥 Checkout repository
+    - name: ðŸ“¥ Checkout repository
       uses: actions/checkout@v4
       with:
         fetch-depth: 1
         
-    - name: 🛠️ Setup Environment
+    - name: ðŸ› ï¸ Setup Environment
       uses: ./.github/actions/setup-environment
         
-    - name: 🚀 Publish and Package
+    - name: ðŸš€ Publish and Package
       uses: ./.github/actions/publish-package
       with:
         runtime-id: ${{ matrix.platform }}
         configuration: ${{ inputs.configuration }}
         package: ${{ inputs.create-packages }}
         
-    - name: 📦 Upload artifacts
+    - name: ðŸ“¦ Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: build-${{ matrix.platform }}

--- a/.github/workflows/_reusable-multiplatform.yml
+++ b/.github/workflows/_reusable-multiplatform.yml
@@ -59,7 +59,7 @@ jobs:
         configuration: ${{ inputs.configuration }}
         package: ${{ inputs.create-packages }}
         
-    - name: ðŸ“¦ Upload artifacts
+    - name: 📦 Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: build-${{ matrix.platform }}

--- a/.github/workflows/_reusable-multiplatform.yml
+++ b/.github/workflows/_reusable-multiplatform.yml
@@ -44,7 +44,7 @@ jobs:
             os: macos-latest
     
     steps:
-    - name: ðŸ“¥ Checkout repository
+    - name: 📥 Checkout repository
       uses: actions/checkout@v4
       with:
         fetch-depth: 1

--- a/build.ps1
+++ b/build.ps1
@@ -13,10 +13,10 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 # CONFIGURATION
 ###########################################################################
 
-$BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
-$TempDirectory = "$PSScriptRoot\\.nuke\temp"
+$BuildProjectFile = (Join-Path (Join-Path $PSScriptRoot "build") "_build.csproj")
+$TempDirectory = (Join-Path (Join-Path $PSScriptRoot ".nuke") "temp")
 
-$DotNetGlobalFile = "$PSScriptRoot\\global.json"
+$DotNetGlobalFile = (Join-Path $PSScriptRoot "global.json")
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
 $DotNetChannel = "STS"
 
@@ -39,7 +39,7 @@ if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
 }
 else {
     # Download install script
-    $DotNetInstallFile = "$TempDirectory\dotnet-install.ps1"
+    $DotNetInstallFile = (Join-Path $TempDirectory "dotnet-install.ps1")
     New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
@@ -53,13 +53,13 @@ else {
     }
 
     # Install by channel or version
-    $DotNetDirectory = "$TempDirectory\dotnet-win"
+    $DotNetDirectory = (Join-Path $TempDirectory "dotnet-win")
     if (!(Test-Path variable:DotNetVersion)) {
         ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
     } else {
         ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
     }
-    $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+    $env:DOTNET_EXE = (Join-Path $DotNetDirectory "dotnet.exe")
     $env:PATH = "$DotNetDirectory;$env:PATH"
 }
 

--- a/src/AGI.Kapster.Desktop/App.axaml.cs
+++ b/src/AGI.Kapster.Desktop/App.axaml.cs
@@ -97,17 +97,18 @@ public partial class App : Application
                     // Settings service initializes automatically
                     Log.Debug("Settings service initialized");
 
-                    // Initialize application controller
-                    var appController = Services!.GetRequiredService<IApplicationController>();
-                    await appController.InitializeAsync();
-                    Log.Debug("Application controller initialized");
-
-                    // Initialize hotkey manager
+                    // Initialize hotkey manager first so global shortcuts work immediately after startup.
                     Log.Debug("Getting hotkey manager service...");
                     var hotkeyManager = Services!.GetRequiredService<IHotkeyManager>();
                     Log.Debug("Hotkey manager service obtained, initializing...");
-                    await hotkeyManager.InitializeAsync();
-                    Log.Debug("Hotkey manager initialized");
+                    var hotkeyTask = hotkeyManager.InitializeAsync();
+
+                    // Initialize application controller (startup settings, etc).
+                    var appController = Services!.GetRequiredService<IApplicationController>();
+                    var appControllerTask = appController.InitializeAsync();
+
+                    await Task.WhenAll(hotkeyTask, appControllerTask);
+                    Log.Debug("Hotkey manager and application controller initialized");
                 }
                 catch (Exception ex)
                 {

--- a/src/AGI.Kapster.Desktop/Services/Hotkeys/HotkeyManager.cs
+++ b/src/AGI.Kapster.Desktop/Services/Hotkeys/HotkeyManager.cs
@@ -154,7 +154,7 @@ public class HotkeyManager : IHotkeyManager
                 }
                 else
                 {
-                    Avalonia.Threading.Dispatcher.UIThread.Post(async () => await StartCaptureSessionAsync());
+                    Avalonia.Threading.Dispatcher.UIThread.Post(() => StartCaptureSessionAsync());
                 }
             });
 

--- a/src/AGI.Kapster.Desktop/Services/Hotkeys/WindowsHotkeyProvider.cs
+++ b/src/AGI.Kapster.Desktop/Services/Hotkeys/WindowsHotkeyProvider.cs
@@ -240,7 +240,7 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
     {
         if (string.IsNullOrEmpty(keyName)) return 0;
 
-        // Letters/digits
+        // Map SharpHook KeyCode names (e.g., VcA, Vc1) to Windows virtual key codes for letters and digits
         if (keyName.Length == 3 && keyName.StartsWith("Vc", StringComparison.Ordinal))
         {
             char c = keyName[2];

--- a/src/AGI.Kapster.Desktop/Services/Hotkeys/WindowsHotkeyProvider.cs
+++ b/src/AGI.Kapster.Desktop/Services/Hotkeys/WindowsHotkeyProvider.cs
@@ -1,23 +1,45 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
+
 using Avalonia.Threading;
 using SharpHook;
-using SharpHook.Native;
+using SharpHook.Data;
 using Serilog;
 
 namespace AGI.Kapster.Desktop.Services.Hotkeys;
 
 /// <summary>
-/// Windows hotkey provider using SharpHook global hook
+/// Windows hotkey provider using SharpHook global hook.
 /// </summary>
 public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
 {
-    private readonly Dictionary<string, (HotkeyModifiers modifiers, uint keyCode, Action callback)> _registeredHotkeys = new();
-    private TaskPoolGlobalHook? _hook;
-    private bool _disposed = false;
     private readonly object _lockObject = new();
+
+    // Hotkey lookup (O(1))
+    private readonly Dictionary<(HotkeyModifiers Modifiers, uint KeyCode), Action> _hotkeysByChord = new();
+    private readonly Dictionary<string, (HotkeyModifiers Modifiers, uint KeyCode)> _chordById = new();
+
+    private EventLoopGlobalHook? _hook;
+    private readonly TaskCompletionSource _runRequestedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private bool _disposed = false;
     private HotkeyModifiers _currentModifiers = HotkeyModifiers.None;
+
+    private static readonly IReadOnlyDictionary<KeyCode, HotkeyModifiers> ModifierByKeyCode = new Dictionary<KeyCode, HotkeyModifiers>
+    {
+        { KeyCode.VcLeftControl, HotkeyModifiers.Control },
+        { KeyCode.VcRightControl, HotkeyModifiers.Control },
+        { KeyCode.VcLeftAlt, HotkeyModifiers.Alt },
+        { KeyCode.VcRightAlt, HotkeyModifiers.Alt },
+        { KeyCode.VcLeftShift, HotkeyModifiers.Shift },
+        { KeyCode.VcRightShift, HotkeyModifiers.Shift },
+        { KeyCode.VcLeftMeta, HotkeyModifiers.Win },
+        { KeyCode.VcRightMeta, HotkeyModifiers.Win },
+    };
+
+    private static readonly IReadOnlyDictionary<KeyCode, uint> VkByKeyCode = BuildVkByKeyCode();
 
     public bool IsSupported => OperatingSystem.IsWindows();
     public bool HasPermissions => true; // SharpHook handles permissions
@@ -33,26 +55,53 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
         InitializeHook();
     }
 
+    private static IReadOnlyDictionary<KeyCode, uint> BuildVkByKeyCode()
+    {
+        var map = new Dictionary<KeyCode, uint>();
+        foreach (var keyCode in Enum.GetValues<KeyCode>())
+        {
+            // Build once; avoid ToString allocations on the hot path.
+            var vk = MapToWindowsVkFromName(keyCode.ToString());
+            if (vk != 0)
+            {
+                map[keyCode] = vk;
+            }
+        }
+
+        return map;
+    }
+
     private void InitializeHook()
     {
         try
         {
-            _hook = new TaskPoolGlobalHook();
+            _hook = new EventLoopGlobalHook();
+            _hook.HookEnabled += OnHookEnabled;
+            _hook.HookDisabled += OnHookDisabled;
             _hook.KeyPressed += OnKeyPressed;
             _hook.KeyReleased += OnKeyReleased;
 
-            // Start the global hook
-            Task.Run(async () =>
+            Task runTask;
+            try
             {
-                try
+                // Start the global hook (non-blocking). The returned task completes when the hook stops/disposes.
+                runTask = _hook.RunAsync();
+                _runRequestedTcs.TrySetResult();
+            }
+            catch (Exception ex)
+            {
+                _runRequestedTcs.TrySetResult();
+                Log.Error(ex, "Error starting SharpHook global hook");
+                return;
+            }
+
+            _ = runTask.ContinueWith(t =>
+            {
+                if (t.Exception != null)
                 {
-                    await _hook.RunAsync();
+                    Log.Error(t.Exception, "Error running SharpHook global hook");
                 }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Error running SharpHook global hook");
-                }
-            });
+            }, TaskScheduler.Default);
 
             Log.Debug("SharpHook global hook initialized successfully");
         }
@@ -62,60 +111,105 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
         }
     }
 
+    private void OnHookEnabled(object? sender, HookEventArgs e)
+    {
+        lock (_lockObject)
+        {
+            // Ensure a clean modifier state after startup/restart.
+            _currentModifiers = HotkeyModifiers.None;
+        }
+
+        Log.Debug("SharpHook global hook enabled");
+    }
+
+    private void OnHookDisabled(object? sender, HookEventArgs e)
+    {
+        lock (_lockObject)
+        {
+            _currentModifiers = HotkeyModifiers.None;
+        }
+
+        Log.Debug("SharpHook global hook disabled");
+    }
+
+    /// <summary>
+    /// Wait until the global hook is actually running. This prevents a startup window where hotkeys are registered
+    /// but the hook thread hasn't begun processing events yet.
+    /// </summary>
+    public async Task WaitUntilReadyAsync(TimeSpan timeout)
+    {
+        if (!IsSupported)
+        {
+            return;
+        }
+
+        // Ensure we at least attempted to start the hook.
+        await _runRequestedTcs.Task.ConfigureAwait(false);
+
+        var hook = _hook;
+        if (hook == null)
+        {
+            return;
+        }
+
+        var sw = Stopwatch.StartNew();
+        while (!hook.IsRunning && sw.Elapsed < timeout)
+        {
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+
+        if (!hook.IsRunning)
+        {
+            Log.Warning("SharpHook global hook not running after waiting {TimeoutMs}ms", (int)timeout.TotalMilliseconds);
+        }
+    }
+
     private void OnKeyPressed(object? sender, KeyboardHookEventArgs e)
     {
         try
         {
-            var keyName = e.Data.KeyCode.ToString();
+            var keyCode = e.Data.KeyCode;
 
-            // Do not trigger on pure modifier keys
-            if (IsModifierKeyName(keyName, out var modifierFlag))
+            // Do not trigger on pure modifier keys.
+            if (ModifierByKeyCode.TryGetValue(keyCode, out var modifierFlag))
             {
                 lock (_lockObject)
                 {
                     _currentModifiers |= modifierFlag;
                 }
+
                 return;
             }
 
-            // Non-modifier: combine with current modifiers and match
-            uint vk = MapToWindowsVkFromName(keyName);
-            if (vk == 0)
+            if (!VkByKeyCode.TryGetValue(keyCode, out var vk) || vk == 0)
             {
                 return;
             }
 
-            HotkeyModifiers modifiers;
+            Action? callback;
             lock (_lockObject)
             {
-                modifiers = _currentModifiers;
+                var modifiers = _currentModifiers;
+                _hotkeysByChord.TryGetValue((modifiers, vk), out callback);
             }
 
-            lock (_lockObject)
+            if (callback == null)
             {
-                foreach (var (id, (registeredModifiers, registeredKeyCode, callback)) in _registeredHotkeys)
+                return;
+            }
+
+            // Execute callback on UI thread.
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                try
                 {
-                    if (vk == registeredKeyCode && modifiers == registeredModifiers)
-                    {
-                        Log.Debug("Hotkey matched: {Id} -> {Modifiers}+{KeyCode}", id, modifiers, vk);
-
-                        // Execute callback on UI thread
-                        Dispatcher.UIThread.InvokeAsync(() =>
-                        {
-                            try
-                            {
-                                callback();
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Error(ex, "Error executing hotkey callback: {Id}", id);
-                            }
-                        });
-
-                        break;
-                    }
+                    callback();
                 }
-            }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error executing hotkey callback");
+                }
+            });
         }
         catch (Exception ex)
         {
@@ -127,8 +221,8 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
     {
         try
         {
-            var keyName = e.Data.KeyCode.ToString();
-            if (IsModifierKeyName(keyName, out var modifierFlag))
+            var keyCode = e.Data.KeyCode;
+            if (ModifierByKeyCode.TryGetValue(keyCode, out var modifierFlag))
             {
                 lock (_lockObject)
                 {
@@ -142,23 +236,11 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
         }
     }
 
-    private static bool IsModifierKeyName(string keyName, out HotkeyModifiers flag)
-    {
-        flag = HotkeyModifiers.None;
-
-        if (string.IsNullOrEmpty(keyName)) return false;
-        if (keyName is "VcLeftControl" or "VcRightControl") { flag = HotkeyModifiers.Control; return true; }
-        if (keyName is "VcLeftAlt" or "VcRightAlt") { flag = HotkeyModifiers.Alt; return true; }
-        if (keyName is "VcLeftShift" or "VcRightShift") { flag = HotkeyModifiers.Shift; return true; }
-        if (keyName is "VcLeftMeta" or "VcRightMeta") { flag = HotkeyModifiers.Win; return true; }
-        return false;
-    }
-
     private static uint MapToWindowsVkFromName(string keyName)
     {
         if (string.IsNullOrEmpty(keyName)) return 0;
 
-        // Letters A-Z
+        // Letters/digits
         if (keyName.Length == 3 && keyName.StartsWith("Vc", StringComparison.Ordinal))
         {
             char c = keyName[2];
@@ -256,16 +338,19 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
         {
             lock (_lockObject)
             {
-                // Remove existing if present
-                if (_registeredHotkeys.ContainsKey(id))
+                // Remove existing if present.
+                if (_chordById.TryGetValue(id, out var existingChord))
                 {
-                    _registeredHotkeys.Remove(id);
+                    _chordById.Remove(id);
+                    _hotkeysByChord.Remove(existingChord);
                     Log.Debug("Removed existing hotkey: {Id}", id);
                 }
 
-                // Register new hotkey
-                _registeredHotkeys[id] = (modifiers, keyCode, callback);
-                Log.Debug("✅ SharpHook hotkey registered: {Id} -> {Modifiers}+{KeyCode}", id, modifiers, keyCode);
+                var chord = (modifiers, keyCode);
+                _chordById[id] = chord;
+                _hotkeysByChord[chord] = callback;
+
+                Log.Debug("SharpHook hotkey registered: {Id} -> {Modifiers}+{KeyCode}", id, modifiers, keyCode);
                 return true;
             }
         }
@@ -282,11 +367,14 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
         {
             lock (_lockObject)
             {
-                if (_registeredHotkeys.Remove(id))
+                if (_chordById.TryGetValue(id, out var chord))
                 {
+                    _chordById.Remove(id);
+                    _hotkeysByChord.Remove(chord);
                     Log.Debug("SharpHook hotkey unregistered: {Id}", id);
                     return true;
                 }
+
                 return false;
             }
         }
@@ -303,8 +391,9 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
         {
             lock (_lockObject)
             {
-                var count = _registeredHotkeys.Count;
-                _registeredHotkeys.Clear();
+                var count = _chordById.Count;
+                _chordById.Clear();
+                _hotkeysByChord.Clear();
                 Log.Debug("All SharpHook hotkeys unregistered: {Count}", count);
             }
         }
@@ -322,13 +411,14 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
 
         try
         {
-            // 注销所有热键
             UnregisterAll();
 
-            // 停止并释放SharpHook
             if (_hook != null)
             {
+                _hook.HookEnabled -= OnHookEnabled;
+                _hook.HookDisabled -= OnHookDisabled;
                 _hook.KeyPressed -= OnKeyPressed;
+                _hook.KeyReleased -= OnKeyReleased;
                 _hook.Dispose();
                 _hook = null;
                 Log.Debug("SharpHook disposed");
@@ -342,3 +432,4 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
         }
     }
 }
+

--- a/src/AGI.Kapster.Desktop/Services/Hotkeys/WindowsHotkeyProvider.cs
+++ b/src/AGI.Kapster.Desktop/Services/Hotkeys/WindowsHotkeyProvider.cs
@@ -60,7 +60,7 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
         var map = new Dictionary<KeyCode, uint>();
         foreach (var keyCode in Enum.GetValues<KeyCode>())
         {
-            // Build once; avoid ToString allocations on the hot path.
+            // Build once to avoid ToString allocations on the hot path.
             var vk = MapToWindowsVkFromName(keyCode.ToString());
             if (vk != 0)
             {

--- a/src/AGI.Kapster.Desktop/Services/Hotkeys/WindowsHotkeyProvider.cs
+++ b/src/AGI.Kapster.Desktop/Services/Hotkeys/WindowsHotkeyProvider.cs
@@ -134,7 +134,7 @@ public class WindowsHotkeyProvider : IHotkeyProvider, IDisposable
 
     /// <summary>
     /// Wait until the global hook is actually running. This prevents a startup window where hotkeys are registered
-    /// but the hook thread hasn't begun processing events yet.
+    /// but the hook hasn't begun processing events yet.
     /// </summary>
     public async Task WaitUntilReadyAsync(TimeSpan timeout)
     {

--- a/tests/AGI.Kapster.Tests/Services/HotkeyManagerTests.cs
+++ b/tests/AGI.Kapster.Tests/Services/HotkeyManagerTests.cs
@@ -1,9 +1,11 @@
+using System.Threading.Tasks;
+
 using FluentAssertions;
-using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 using Xunit.Abstractions;
-using AGI.Kapster.Desktop.Services;
+
+using AGI.Kapster.Desktop.Models;
 using AGI.Kapster.Desktop.Services.Hotkeys;
 using AGI.Kapster.Desktop.Services.Overlay.Coordinators;
 using AGI.Kapster.Desktop.Services.Settings;
@@ -30,8 +32,46 @@ public class HotkeyManagerTests : TestBase
     [Fact]
     public void Constructor_ShouldInitializeCorrectly()
     {
-        // Act & Assert
         _hotkeyManager.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WhenSupportedAndPermitted_ShouldRegisterConfiguredHotkeys()
+    {
+        // Arrange
+        _hotkeyProvider.IsSupported.Returns(true);
+        _hotkeyProvider.HasPermissions.Returns(true);
+
+        var settings = new AppSettings
+        {
+            Hotkeys = new HotkeySettings
+            {
+                CaptureRegion = "Ctrl+Shift+A",
+                OpenSettings = "Alt+S"
+            }
+        };
+        _settingsService.Settings.Returns(settings);
+
+        _hotkeyProvider.RegisterHotkey(Arg.Any<string>(), Arg.Any<HotkeyModifiers>(), Arg.Any<uint>(), Arg.Any<System.Action>())
+            .Returns(true);
+
+        // Act
+        await _hotkeyManager.InitializeAsync();
+
+        // Assert
+        _hotkeyProvider.Received(1).UnregisterAll();
+
+        _hotkeyProvider.Received(1).RegisterHotkey(
+            "capture_region",
+            HotkeyModifiers.Control | HotkeyModifiers.Shift,
+            65,
+            Arg.Any<System.Action>());
+
+        _hotkeyProvider.Received(1).RegisterHotkey(
+            "open_settings",
+            HotkeyModifiers.Alt,
+            83,
+            Arg.Any<System.Action>());
     }
 
     [Fact]
@@ -40,7 +80,7 @@ public class HotkeyManagerTests : TestBase
         // Arrange
         _hotkeyProvider.IsSupported.Returns(true);
         _hotkeyProvider.HasPermissions.Returns(true);
-        _hotkeyProvider.RegisterHotkey(Arg.Any<string>(), Arg.Any<HotkeyModifiers>(), Arg.Any<uint>(), Arg.Any<Action>())
+        _hotkeyProvider.RegisterHotkey(Arg.Any<string>(), Arg.Any<HotkeyModifiers>(), Arg.Any<uint>(), Arg.Any<System.Action>())
             .Returns(true);
 
         // Act
@@ -51,7 +91,7 @@ public class HotkeyManagerTests : TestBase
             "overlay_escape",
             HotkeyModifiers.None,
             27, // Escape key code
-            Arg.Any<Action>()
+            Arg.Any<System.Action>()
         );
     }
 
@@ -61,7 +101,7 @@ public class HotkeyManagerTests : TestBase
         // Arrange
         _hotkeyProvider.IsSupported.Returns(true);
         _hotkeyProvider.HasPermissions.Returns(true);
-        _hotkeyProvider.RegisterHotkey(Arg.Any<string>(), Arg.Any<HotkeyModifiers>(), Arg.Any<uint>(), Arg.Any<Action>())
+        _hotkeyProvider.RegisterHotkey(Arg.Any<string>(), Arg.Any<HotkeyModifiers>(), Arg.Any<uint>(), Arg.Any<System.Action>())
             .Returns(true);
 
         // Act
@@ -72,7 +112,7 @@ public class HotkeyManagerTests : TestBase
             Arg.Any<string>(),
             Arg.Any<HotkeyModifiers>(),
             Arg.Any<uint>(),
-            Arg.Any<Action>()
+            Arg.Any<System.Action>()
         );
     }
 
@@ -96,7 +136,7 @@ public class HotkeyManagerTests : TestBase
         // Arrange
         _hotkeyProvider.IsSupported.Returns(true);
         _hotkeyProvider.HasPermissions.Returns(true);
-        _hotkeyProvider.RegisterHotkey(Arg.Any<string>(), Arg.Any<HotkeyModifiers>(), Arg.Any<uint>(), Arg.Any<Action>())
+        _hotkeyProvider.RegisterHotkey(Arg.Any<string>(), Arg.Any<HotkeyModifiers>(), Arg.Any<uint>(), Arg.Any<System.Action>())
             .Returns(true);
 
         // First register the hotkey
@@ -123,7 +163,7 @@ public class HotkeyManagerTests : TestBase
             Arg.Any<string>(),
             Arg.Any<HotkeyModifiers>(),
             Arg.Any<uint>(),
-            Arg.Any<Action>()
+            Arg.Any<System.Action>()
         );
     }
 
@@ -142,7 +182,7 @@ public class HotkeyManagerTests : TestBase
             Arg.Any<string>(),
             Arg.Any<HotkeyModifiers>(),
             Arg.Any<uint>(),
-            Arg.Any<Action>()
+            Arg.Any<System.Action>()
         );
     }
 }


### PR DESCRIPTION
- Windows: switch SharpHook hook implementation to improve hotkey reliability and responsiveness\n- Add Windows hook readiness wait during startup\n- Limit macOS permission delay logic to macOS only\n- Remove redundant UI-thread dispatch for capture hotkey\n- Add/adjust tests for HotkeyManager initialization\n\nNotes:\n- No behavior changes to macOS/Linux hotkey providers\n- Tests: dotnet test (passed)